### PR TITLE
(re-) enable compilation of altera_tse and intel_fpga_qse_ll drivers as kernel module

### DIFF
--- a/drivers/net/ethernet/altera/Kconfig
+++ b/drivers/net/ethernet/altera/Kconfig
@@ -18,7 +18,7 @@ config ALTERA_TSE
 	  This driver supports the Altera Triple-Speed (TSE) Ethernet MAC.
 
 	  To compile this driver as a module, choose M here. The module
-	  will be called alteratse.
+	  will be called altera_tse.
 
 config INTEL_FPGA_QSE_LL
 	tristate "Intel FPGA Quad-Speed Low Latency Ethernet MAC support"

--- a/drivers/net/ethernet/altera/Makefile
+++ b/drivers/net/ethernet/altera/Makefile
@@ -7,12 +7,9 @@ obj-$(CONFIG_NET_ALTERA_ETH) += altera_eth.o
 altera_eth-objs := altera_utils.o intel_fpga_tod.o altera_eth_dma.o \
 		   altera_sgdma.o altera_msgdma.o \
 		   altera_msgdma_prefetcher.o
-ifeq ($(CONFIG_ALTERA_TSE),y)
-	obj-$(CONFIG_ALTERA_TSE) += altera_tse.o
-	altera_tse-objs := altera_tse_main.o altera_tse_ethtool.o
-endif
-ifeq ($(CONFIG_INTEL_FPGA_QSE_LL),y)
-	obj-$(CONFIG_INTEL_FPGA_QSE_LL) += intel_fpga_qse_ll.o
-	intel_fpga_qse_ll-objs := intel_fpga_qse_ll_main.o intel_fpga_qse_ll_ethtool.o
-endif
 
+obj-$(CONFIG_ALTERA_TSE) += altera_tse.o
+altera_tse-objs := altera_tse_main.o altera_tse_ethtool.o
+
+obj-$(CONFIG_INTEL_FPGA_QSE_LL) += intel_fpga_qse_ll.o
+intel_fpga_qse_ll-objs := intel_fpga_qse_ll_main.o intel_fpga_qse_ll_ethtool.o

--- a/drivers/net/ethernet/altera/altera_msgdma.c
+++ b/drivers/net/ethernet/altera/altera_msgdma.c
@@ -14,14 +14,17 @@ int msgdma_initialize(struct altera_dma_private *priv)
 {
 	return 0;
 }
+EXPORT_SYMBOL(msgdma_initialize);
 
 void msgdma_uninitialize(struct altera_dma_private *priv)
 {
 }
+EXPORT_SYMBOL(msgdma_uninitialize);
 
 void msgdma_start_rxdma(struct altera_dma_private *priv)
 {
 }
+EXPORT_SYMBOL(msgdma_start_rxdma);
 
 void msgdma_reset(struct altera_dma_private *priv)
 {
@@ -70,40 +73,47 @@ void msgdma_reset(struct altera_dma_private *priv)
 	/* clear all status bits */
 	csrwr32(MSGDMA_CSR_STAT_MASK, priv->tx_dma_csr, msgdma_csroffs(status));
 }
+EXPORT_SYMBOL(msgdma_reset);
 
 void msgdma_disable_rxirq(struct altera_dma_private *priv)
 {
 	tse_clear_bit(priv->rx_dma_csr, msgdma_csroffs(control),
 		      MSGDMA_CSR_CTL_GLOBAL_INTR);
 }
+EXPORT_SYMBOL(msgdma_disable_rxirq);
 
 void msgdma_enable_rxirq(struct altera_dma_private *priv)
 {
 	tse_set_bit(priv->rx_dma_csr, msgdma_csroffs(control),
 		    MSGDMA_CSR_CTL_GLOBAL_INTR);
 }
+EXPORT_SYMBOL(msgdma_enable_rxirq);
 
 void msgdma_disable_txirq(struct altera_dma_private *priv)
 {
 	tse_clear_bit(priv->tx_dma_csr, msgdma_csroffs(control),
 		      MSGDMA_CSR_CTL_GLOBAL_INTR);
 }
+EXPORT_SYMBOL(msgdma_disable_txirq);
 
 void msgdma_enable_txirq(struct altera_dma_private *priv)
 {
 	tse_set_bit(priv->tx_dma_csr, msgdma_csroffs(control),
 		    MSGDMA_CSR_CTL_GLOBAL_INTR);
 }
+EXPORT_SYMBOL(msgdma_enable_txirq);
 
 void msgdma_clear_rxirq(struct altera_dma_private *priv)
 {
 	csrwr32(MSGDMA_CSR_STAT_IRQ, priv->rx_dma_csr, msgdma_csroffs(status));
 }
+EXPORT_SYMBOL(msgdma_clear_rxirq);
 
 void msgdma_clear_txirq(struct altera_dma_private *priv)
 {
 	csrwr32(MSGDMA_CSR_STAT_IRQ, priv->tx_dma_csr, msgdma_csroffs(status));
 }
+EXPORT_SYMBOL(msgdma_clear_txirq);
 
 /* return 0 to indicate transmit is pending */
 netdev_tx_t msgdma_tx_buffer(struct altera_dma_private *priv,
@@ -123,6 +133,7 @@ netdev_tx_t msgdma_tx_buffer(struct altera_dma_private *priv,
 		msgdma_descroffs(control));
 	return NETDEV_TX_OK;
 }
+EXPORT_SYMBOL(msgdma_tx_buffer);
 
 u32 msgdma_tx_completions(struct altera_dma_private *priv)
 {
@@ -147,6 +158,7 @@ u32 msgdma_tx_completions(struct altera_dma_private *priv)
 	}
 	return ready;
 }
+EXPORT_SYMBOL(msgdma_tx_completions);
 
 /* Put buffer to the mSGDMA RX FIFO
  */
@@ -173,6 +185,7 @@ void msgdma_add_rx_desc(struct altera_dma_private *priv,
 	csrwr32(0x00010001, priv->rx_dma_desc, msgdma_descroffs(stride));
 	csrwr32(control, priv->rx_dma_desc, msgdma_descroffs(control));
 }
+EXPORT_SYMBOL(msgdma_add_rx_desc);
 
 /* status is returned on upper 16 bits,
  * length is returned in lower 16 bits
@@ -195,3 +208,4 @@ u32 msgdma_rx_status(struct altera_dma_private *priv)
 	}
 	return rxstatus;
 }
+EXPORT_SYMBOL(msgdma_rx_status);

--- a/drivers/net/ethernet/altera/altera_msgdma_prefetcher.c
+++ b/drivers/net/ethernet/altera/altera_msgdma_prefetcher.c
@@ -111,6 +111,7 @@ err_tx:
 err_rx:
 	return -ENOMEM;
 }
+EXPORT_SYMBOL(msgdma_pref_initialize);
 
 void msgdma_pref_uninitialize(struct altera_dma_private *priv)
 {
@@ -126,42 +127,49 @@ void msgdma_pref_uninitialize(struct altera_dma_private *priv)
 				  * priv->tx_ring_size * 2,
 				  priv->pref_txdesc, priv->pref_txdescphys);
 }
+EXPORT_SYMBOL(msgdma_pref_uninitialize);
 
 void msgdma_pref_enable_txirq(struct altera_dma_private *priv)
 {
 	tse_set_bit(priv->tx_pref_csr, msgdma_pref_csroffs(control),
 		    MSGDMA_PREF_CTL_GLOBAL_INTR);
 }
+EXPORT_SYMBOL(msgdma_pref_enable_txirq);
 
 void msgdma_pref_disable_txirq(struct altera_dma_private *priv)
 {
 	tse_clear_bit(priv->tx_pref_csr, msgdma_pref_csroffs(control),
 		      MSGDMA_PREF_CTL_GLOBAL_INTR);
 }
+EXPORT_SYMBOL(msgdma_pref_disable_txirq);
 
 void msgdma_pref_clear_txirq(struct altera_dma_private *priv)
 {
 	csrwr32(MSGDMA_PREF_STAT_IRQ, priv->tx_pref_csr,
 		msgdma_pref_csroffs(status));
 }
+EXPORT_SYMBOL(msgdma_pref_clear_txirq);
 
 void msgdma_pref_enable_rxirq(struct altera_dma_private *priv)
 {
 	tse_set_bit(priv->rx_pref_csr, msgdma_pref_csroffs(control),
 		    MSGDMA_PREF_CTL_GLOBAL_INTR);
 }
+EXPORT_SYMBOL(msgdma_pref_enable_rxirq);
 
 void msgdma_pref_disable_rxirq(struct altera_dma_private *priv)
 {
 	tse_clear_bit(priv->rx_pref_csr, msgdma_pref_csroffs(control),
 		      MSGDMA_PREF_CTL_GLOBAL_INTR);
 }
+EXPORT_SYMBOL(msgdma_pref_disable_rxirq);
 
 void msgdma_pref_clear_rxirq(struct altera_dma_private *priv)
 {
 	csrwr32(MSGDMA_PREF_STAT_IRQ, priv->rx_pref_csr,
 		msgdma_pref_csroffs(status));
 }
+EXPORT_SYMBOL(msgdma_pref_clear_rxirq);
 
 static u64 timestamp_to_ns(struct msgdma_pref_extended_desc *desc)
 {
@@ -220,6 +228,7 @@ netdev_tx_t msgdma_pref_tx_buffer(struct altera_dma_private *priv,
 
 	return NETDEV_TX_OK;
 }
+EXPORT_SYMBOL(msgdma_pref_tx_buffer);
 
 u32 msgdma_pref_tx_completions(struct altera_dma_private *priv)
 {
@@ -274,6 +283,7 @@ u32 msgdma_pref_tx_completions(struct altera_dma_private *priv)
 
 	return ready;
 }
+EXPORT_SYMBOL(msgdma_pref_tx_completions);
 
 void msgdma_pref_reset(struct altera_dma_private *priv)
 {
@@ -330,6 +340,7 @@ void msgdma_pref_reset(struct altera_dma_private *priv)
 	/* Reset mSGDMA dispatchers*/
 	msgdma_reset(priv);
 }
+EXPORT_SYMBOL(msgdma_pref_reset);
 
 /* Setup the RX and TX prefetchers to poll the descriptor chain */
 void msgdma_pref_start_rxdma(struct altera_dma_private *priv)
@@ -343,6 +354,7 @@ void msgdma_pref_start_rxdma(struct altera_dma_private *priv)
 	tse_set_bit(priv->rx_pref_csr, msgdma_pref_csroffs(control),
 		    MSGDMA_PREF_CTL_DESC_POLL_EN | MSGDMA_PREF_CTL_RUN);
 }
+EXPORT_SYMBOL(msgdma_pref_start_rxdma);
 
 void msgdma_pref_start_txdma(struct altera_dma_private *priv)
 {
@@ -355,6 +367,7 @@ void msgdma_pref_start_txdma(struct altera_dma_private *priv)
 	tse_set_bit(priv->tx_pref_csr, msgdma_pref_csroffs(control),
 		    MSGDMA_PREF_CTL_DESC_POLL_EN | MSGDMA_PREF_CTL_RUN);
 }
+EXPORT_SYMBOL(msgdma_pref_start_txdma);
 
 /* Add MSGDMA Prefetcher Descriptor to descriptor list
  *   -> This should never be called when a descriptor isn't available
@@ -391,6 +404,7 @@ void msgdma_pref_add_rx_desc(struct altera_dma_private *priv,
 			    priv->pref_rxdesc[desc_entry].desc_control);
 	}
 }
+EXPORT_SYMBOL(msgdma_pref_add_rx_desc);
 
 u32 msgdma_pref_rx_status(struct altera_dma_private *priv)
 {
@@ -435,3 +449,4 @@ u32 msgdma_pref_rx_status(struct altera_dma_private *priv)
 	}
 	return rxstatus;
 }
+EXPORT_SYMBOL(msgdma_pref_rx_status);

--- a/drivers/net/ethernet/altera/altera_sgdma.c
+++ b/drivers/net/ethernet/altera/altera_sgdma.c
@@ -99,6 +99,7 @@ int sgdma_initialize(struct altera_dma_private *priv)
 
 	return 0;
 }
+EXPORT_SYMBOL(sgdma_initialize);
 
 void sgdma_uninitialize(struct altera_dma_private *priv)
 {
@@ -110,6 +111,7 @@ void sgdma_uninitialize(struct altera_dma_private *priv)
 		dma_unmap_single(priv->device, priv->txdescphys,
 				 priv->txdescmem, DMA_TO_DEVICE);
 }
+EXPORT_SYMBOL(sgdma_uninitialize);
 
 /* This function resets the SGDMA controller and clears the
  * descriptor memory used for transmits and receives.
@@ -126,6 +128,7 @@ void sgdma_reset(struct altera_dma_private *priv)
 	csrwr32(SGDMA_CTRLREG_RESET, priv->rx_dma_csr, sgdma_csroffs(control));
 	csrwr32(0, priv->rx_dma_csr, sgdma_csroffs(control));
 }
+EXPORT_SYMBOL(sgdma_reset);
 
 /* For SGDMA, interrupts remain enabled after initially enabling,
  * so no need to provide implementations for abstract enable
@@ -135,30 +138,36 @@ void sgdma_reset(struct altera_dma_private *priv)
 void sgdma_enable_rxirq(struct altera_dma_private *priv)
 {
 }
+EXPORT_SYMBOL(sgdma_enable_rxirq);
 
 void sgdma_enable_txirq(struct altera_dma_private *priv)
 {
 }
+EXPORT_SYMBOL(sgdma_enable_txirq);
 
 void sgdma_disable_rxirq(struct altera_dma_private *priv)
 {
 }
+EXPORT_SYMBOL(sgdma_disable_rxirq);
 
 void sgdma_disable_txirq(struct altera_dma_private *priv)
 {
 }
+EXPORT_SYMBOL(sgdma_disable_txirq);
 
 void sgdma_clear_rxirq(struct altera_dma_private *priv)
 {
 	tse_set_bit(priv->rx_dma_csr, sgdma_csroffs(control),
 		    SGDMA_CTRLREG_CLRINT);
 }
+EXPORT_SYMBOL(sgdma_clear_rxirq);
 
 void sgdma_clear_txirq(struct altera_dma_private *priv)
 {
 	tse_set_bit(priv->tx_dma_csr, sgdma_csroffs(control),
 		    SGDMA_CTRLREG_CLRINT);
 }
+EXPORT_SYMBOL(sgdma_clear_txirq);
 
 /* transmits buffer through SGDMA.
  *   original behavior returned the number of transmitted packets (always 1) &
@@ -199,6 +208,7 @@ netdev_tx_t sgdma_tx_buffer(struct altera_dma_private *priv,
 
 	return NETDEV_TX_OK;
 }
+EXPORT_SYMBOL(sgdma_tx_buffer);
 
 
 /* tx_lock held to protect access to queued tx list
@@ -216,17 +226,20 @@ u32 sgdma_tx_completions(struct altera_dma_private *priv)
 
 	return ready;
 }
+EXPORT_SYMBOL(sgdma_tx_completions);
 
 void sgdma_start_rxdma(struct altera_dma_private *priv)
 {
 	sgdma_async_read(priv);
 }
+EXPORT_SYMBOL(sgdma_start_rxdma);
 
 void sgdma_add_rx_desc(struct altera_dma_private *priv,
 		       struct altera_dma_buffer *rxbuffer)
 {
 	queue_rx(priv, rxbuffer);
 }
+EXPORT_SYMBOL(sgdma_add_rx_desc);
 
 /* status is returned on upper 16 bits,
  * length is returned in lower 16 bits
@@ -293,7 +306,7 @@ u32 sgdma_rx_status(struct altera_dma_private *priv)
 
 	return rxstatus;
 }
-
+EXPORT_SYMBOL(sgdma_rx_status);
 
 /* Private functions */
 static void sgdma_setup_descrip(struct sgdma_descrip __iomem *desc,

--- a/drivers/net/ethernet/altera/altera_utils.c
+++ b/drivers/net/ethernet/altera/altera_utils.c
@@ -13,6 +13,7 @@ void tse_set_bit(void __iomem *ioaddr, size_t offs, u32 bit_mask)
 	value |= bit_mask;
 	csrwr32(value, ioaddr, offs);
 }
+EXPORT_SYMBOL(tse_set_bit);
 
 void tse_clear_bit(void __iomem *ioaddr, size_t offs, u32 bit_mask)
 {
@@ -20,18 +21,21 @@ void tse_clear_bit(void __iomem *ioaddr, size_t offs, u32 bit_mask)
 	value &= ~bit_mask;
 	csrwr32(value, ioaddr, offs);
 }
+EXPORT_SYMBOL(tse_clear_bit);
 
 int tse_bit_is_set(void __iomem *ioaddr, size_t offs, u32 bit_mask)
 {
 	u32 value = csrrd32(ioaddr, offs);
 	return (value & bit_mask) ? 1 : 0;
 }
+EXPORT_SYMBOL(tse_bit_is_set);
 
 int tse_bit_is_clear(void __iomem *ioaddr, size_t offs, u32 bit_mask)
 {
 	u32 value = csrrd32(ioaddr, offs);
 	return (value & bit_mask) ? 0 : 1;
 }
+EXPORT_SYMBOL(tse_bit_is_clear);
 
 int request_and_map(struct platform_device *pdev, const char *name,
 		    struct resource **res, void __iomem **ptr)
@@ -61,3 +65,4 @@ int request_and_map(struct platform_device *pdev, const char *name,
 
 	return 0;
 }
+EXPORT_SYMBOL(request_and_map);

--- a/drivers/net/ethernet/altera/intel_fpga_tod.c
+++ b/drivers/net/ethernet/altera/intel_fpga_tod.c
@@ -301,6 +301,7 @@ int intel_fpga_tod_register(struct intel_fpga_tod_private *priv,
 
 	return ret;
 }
+EXPORT_SYMBOL(intel_fpga_tod_register);
 
 /* Remove/unregister the ptp clock driver from the kernel */
 void intel_fpga_tod_unregister(struct intel_fpga_tod_private *priv)
@@ -313,6 +314,7 @@ void intel_fpga_tod_unregister(struct intel_fpga_tod_private *priv)
 	if (priv->tod_clk)
 		clk_disable_unprepare(priv->tod_clk);
 }
+EXPORT_SYMBOL(intel_fpga_tod_unregister);
 
 /* Common PTP probe function */
 int intel_fpga_tod_probe(struct platform_device *pdev,
@@ -344,5 +346,6 @@ int intel_fpga_tod_probe(struct platform_device *pdev,
 err:
 	return ret;
 }
+EXPORT_SYMBOL(intel_fpga_tod_probe);
 
 MODULE_LICENSE("GPL");


### PR DESCRIPTION
Currently, when these modules are configured as a module, they will not be built at all.

This patch is also needed in other branches, e.g. 5.10-50-lts.