### PR TITLE
crypto: intel_fcs: check platform name when invoke mmap

### DIFF
--- a/drivers/crypto/intel_fcs_main.c
+++ b/drivers/crypto/intel_fcs_main.c
@@ -95,6 +95,7 @@ struct socfpga_fcs_data {
 	bool have_hwrng;
 };
 
+static const char *platform;
 static char *source_ptr;
 
 typedef void (*fcs_callback)(struct stratix10_svc_client *client,
@@ -3730,6 +3731,9 @@ static int fcs_mmap(struct file *filp, struct vm_area_struct *vma)
 	unsigned long size, off;
 	struct page *page;
 
+	if (strncmp(platform, AGILEX_PLATFORM, AGILEX_PLATFORM_STR_LEN))
+		return -ENOTSUPP;
+
 	if (!source_ptr) {
 		pr_err("vmalloc failed mmap %s", __func__);
 		return -ENOMEM;
@@ -3762,7 +3766,6 @@ static int fcs_driver_probe(struct platform_device *pdev)
 	struct device *dev = &pdev->dev;
 	struct intel_fcs_priv *priv;
 	int ret, i;
-	const char *platform;
 	struct stratix10_svc_client_msg msg;
 	unsigned long off;
 	int l2_idx = SRC_BUFFER_STARTING_L2_IDX;


### PR DESCRIPTION
fcs_mmap() is specific for Agilex board SMMU feature, other boards like Stratix10 and N5X don't support SMMU, if called mmap() with fcs_client command on those two boards will get error message "vmalloc failed mmap fcs_mmap" continuously, because the variables in fcs_mmap are initialized under condition that platform is named "agilex" in FCS probe stage, so add the same check in fcs_mmap() to avoid print useless and annoying info on those boards which don't support SMMU.