### PR TITLE
net: eth: altera: fix phy-handle not find issue

### DIFF
--- a/drivers/net/ethernet/altera/altera_tse_main.c
+++ b/drivers/net/ethernet/altera/altera_tse_main.c
@@ -936,18 +936,19 @@ static int init_phy(struct net_device *dev)
 
 	ret = phylink_of_phy_connect(priv->phylink, priv->device->of_node, 0);
 
-	if (ret) {
-		netdev_dbg(dev, "no phy-handle found\n");
-		if (!priv->mdio) {
-			netdev_err(dev, "No phy-handle nor local mdio specified\n");
+	if (!ret)
+		return ret;
+
+	netdev_dbg(dev, "no phy-handle found\n");
+	if (!priv->mdio) {
+		netdev_err(dev, "No phy-handle nor local mdio specified\n");
+		return -ENODEV;
+	}
+	phydev = connect_local_phy(dev);
+	if (phydev) {
+		ret = phylink_connect_phy(priv->phylink, phydev);
+		if (ret)
 			return -ENODEV;
-		}
-		phydev = connect_local_phy(dev);
-		if (phydev) {
-			ret = phylink_connect_phy(priv->phylink, phydev);
-			if (ret)
-				return -ENODEV;
-		}
 	}
 
 	if (!phydev) {


### PR DESCRIPTION
Description: 
The function _phylink_of_phy_connect()_ returns 0 in case of success. 
So, if the _phy-handle_ attribute was found, it will return 0, but _phydev_ will still contain the value _NULL_, and it will enter the condition _if(!phydev)_ and return an error even in the successful case.

Impact Analysis:

What is the scope of the change and the purpose of the change?
It will return the same value as _phylink_of_phy_connect()_ in case of success, the value 0. So, there is no need to check the condition _if(!phydev)_.
